### PR TITLE
docs: fix references page

### DIFF
--- a/docs/src/references/README.md
+++ b/docs/src/references/README.md
@@ -1,1 +1,13 @@
+---
+title: Permaweb Cookbook - References
+---
+
 # References
+
+References for learning in depth about various topics like Bundling, GraphQL, and HTTP APIs.
+
+- [Bundling](bundling.md)
+- [GraphQL](gql.md)
+- [HTTP API](http-api)
+
+> Do you think a permaweb guide is missing? Create a issue at [Github](https://github.com/twilson63/permaweb-cookbook/issues) or consider [contributing](../getting-started/contributing.md)


### PR DESCRIPTION
Added the links to the subtopics for the references and the closing line of contributing to the GitHub repo of the cookbook